### PR TITLE
Fix attempt by testing for _model on points

### DIFF
--- a/src/elements/element.line.js
+++ b/src/elements/element.line.js
@@ -21,10 +21,11 @@ module.exports = function(Chart) {
 		lineToNextPoint: function(previousPoint, point, nextPoint, skipHandler, previousSkipHandler) {
 			var me = this;
 			var ctx = me._chart.ctx;
+			var spanGaps = me._model ? me._model.spanGaps : false;
 
-			if (point._view.skip && !me._model.spanGaps) {
+			if (point._view.skip && !spanGaps) {
 				skipHandler.call(me, previousPoint, point, nextPoint);
-			} else if (previousPoint._view.skip && !me._model.spanGaps) {
+			} else if (previousPoint._view.skip && !spanGaps) {
 				previousSkipHandler.call(me, previousPoint, point, nextPoint);
 			} else if (point._view.tension === 0) {
 				ctx.lineTo(point._view.x, point._view.y);


### PR DESCRIPTION
I fixed the tests by adding a very swift check in lineToNextPoint() in element.line. This was necessary because the tests--presumably adding points in a way that one might see in the wild--adds points manually, bypassing the line._model setup.

My options were to either alter the tests, thereby breaking potential functionality, or to add the quick check to lineToNextPoint(). I settled on the latter for backward compatibility's sake.